### PR TITLE
Conda - basin setup - Pin mpich

### DIFF
--- a/conda/basin_setup.yaml
+++ b/conda/basin_setup.yaml
@@ -8,7 +8,7 @@ dependencies:
   - gcc_linux-64=7
   - gdal=3.3
   - geopandas<0.10
-  - mpich
+  - mpich=3.4
   - netcdf4>=1.4.1
   - numpy<1.20
   - pandas>=1.0


### PR DESCRIPTION
Set the mpich version to 3.4.
TauDEM requires a 3.x version to compile