### PR TITLE
Conda - basin setup - Updates to use tauDEM

### DIFF
--- a/conda/basin_setup.yaml
+++ b/conda/basin_setup.yaml
@@ -2,13 +2,10 @@ name: basin_setup
 channels:
   - conda-forge
 dependencies:
-  - cmake
-  - colorama
-  - coloredlogs
-  - gcc_linux-64=7
-  - gdal=3.3
+  - taudem
+  - colorama=0.3.9
+  - coloredlogs=10.0
   - geopandas<0.10
-  - mpich=3.4
   - netcdf4>=1.4.1
   - numpy<1.20
   - pandas>=1.0
@@ -21,3 +18,4 @@ dependencies:
       - inicheck>=0.9,<0.10.0
       - spatialnc>=0.3.0,<0.4.0
       - cftime<1.1.0
+


### PR DESCRIPTION
Use the tauDEM conda package along with adding version numbers
to colorama and coloredlogs. Removes the libraries needed to compile
tauDEM from source.