### PR TITLE
Updates for install

### DIFF
--- a/conda/environment.yml
+++ b/conda/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - cftime=1.5.2
   - coloredlogs
   - cython
-  - dateparser=0.7.4
+  - dateparser=0.7.2
   - gcc=8.5.0
   - make
   - nco

--- a/conda/environment_Mac_OSX.yml
+++ b/conda/environment_Mac_OSX.yml
@@ -1,0 +1,31 @@
+name: isnoda
+channels:
+- conda-forge
+dependencies:
+- beautifulsoup4
+- cfgrib
+- cftime=1.5.2
+- clang_osx-64=12
+- coloredlogs
+- cython
+- dateparser=0.7.2
+- llvm-openmp
+- make
+- numpy=1.20.3
+- openmpi=4
+- pandas=1.3.5
+- pip
+- progressbar2
+- pykrige
+- python=3.7
+- pytz
+- pyyaml
+- regex=2020.2.20
+- requests
+- scipy[version='<1.7.0']
+- setuptools_scm[version='<4.2']
+- siphon
+- urllib3
+- utm
+- xarray=0.15.1
+


### PR DESCRIPTION
Two improvements with this PR:
* Downgrade `dateparser` library to work out of the box with the pip install version of `inicheck`
* Add Mac OS X specific environment.yml to support installation on a macOS Ventura (13)