### PR TITLE
Snobedo package - Update Dask helper

### DIFF
--- a/package/src/snobedo/lib/dask_utils.py
+++ b/package/src/snobedo/lib/dask_utils.py
@@ -38,6 +38,16 @@ def client_ip_and_port(client):
     print(client.dashboard_link.split('/')[2])
 
 
+def slurm_script(client):
+    """
+    Print the slurm script that would be submitted to start the cluster
+
+    :param client: Instance of dask.distributed.Client
+    :return: str: slurm script
+    """
+    print(client.jobscript())
+
+
 @contextmanager
 def run_with_client(cores, memory):
     client = start_cluster(cores, memory)

--- a/package/src/snobedo/lib/dask_utils.py
+++ b/package/src/snobedo/lib/dask_utils.py
@@ -1,30 +1,33 @@
 from contextlib import contextmanager
-from pathlib import Path
 
 from dask.distributed import Client
 
-CHPC = 'chpc' in str(Path.home())
 
+def start_cluster(cores=6, memory=None, local=False):
+    """
+    Start up a Dask cluster with requested resources.
+    Default is to use a remote sever and use SLURM to request the resources.
 
-def start_cluster(cores=6, memory=None):
-    if CHPC:
+    :param cores: Number of needed cores
+    :param memory: Total memory across all cores
+    :param local: Start a local cluster instead using a remote server
+    :return: Dask Client object to interact with the cluster
+    """
+    if local:
+        from dask.distributed import LocalCluster
+
+        memory = memory / cores
+        cluster = LocalCluster(n_workers=cores, memory_limit=f"{memory}G")
+    else:
         from dask_jobqueue import SLURMCluster
 
         cluster = SLURMCluster(
             cores=cores,
             processes=cores,
             n_workers=1,
-            account="notchpeak-shared-short",
-            queue="notchpeak-shared-short",
             memory=f"{memory or cores}G",
             walltime="2:00:00",
         )
-    else:
-        # Assume local
-        from dask.distributed import LocalCluster
-
-        memory = memory / cores
-        cluster = LocalCluster(n_workers=cores, memory_limit=f"{memory}G")
 
     return Client(cluster)
 


### PR DESCRIPTION
Changes the helper methods to interact with Dask and adds a debug method to troubleshoot SLURM startup issues. This mainly removes hard coded settings to run on CHPC and makes it more general to also run at BSU :smile: 