### PR TITLE
Conda - Install  - Change default install location name

### DIFF
--- a/conda/install_isnoda.sh
+++ b/conda/install_isnoda.sh
@@ -2,10 +2,10 @@
 # Script to install all required components from GitHub repositories.
 #
 # These components are installed with the latest from the master branch:
-#  - AWSM (Universit of Utah)
-#  - SMRF (Universit of Utah)
-#  - PySnobal (ARs)
-#  - Weather Forecast Retrieval (Universit of Utah)
+#  - AWSM (University of Utah)
+#  - SMRF (University of Utah)
+#  - PySnobal (ARS)
+#  - Weather Forecast Retrieval (University of Utah)
 #
 # Other packages are installed via the latest available version as pip package.
 # 
@@ -13,7 +13,7 @@
 
 set -e
 
-ISNODA_HOME=${1:-$HOME/isnoda}
+ISNODA_HOME=${1:-$HOME/iSnobal}
 mkdir -p ${ISNODA_HOME}
 
 cd $ISNODA_HOME


### PR DESCRIPTION
Changing the name to `iSnobal` to reduce confusing between this git repository and the folder containing the actual model components.

Fixes #65 