### PR TITLE
Parallel HRRR dowlonad

### DIFF
--- a/scripts/HRRR/HRRR.slurm
+++ b/scripts/HRRR/HRRR.slurm
@@ -36,9 +36,4 @@ for NEXT in {0..2}; do
     >&2 echo "ERROR processing ${CURRENT_YEAR}${CURRENT_MONTH}"
     exit
   fi
-
-  >&1 echo "  Archiving"
-
-  ARCHIVE="hrrr-${CURRENT_YEAR}${CURRENT_MONTH}.tar.bz2"
-  tar -I pbzip2 -cf ${ARCHIVE} hrrr.${CURRENT_YEAR}${CURRENT_MONTH}[0-3][0-9]
 done

--- a/scripts/HRRR/download_hrrr.sh
+++ b/scripts/HRRR/download_hrrr.sh
@@ -104,11 +104,14 @@ download_hrrr() {
 
   printf "  File: ${FILE_NAME}"
 
+  # Clean up any old temporary pipes from previous runs
+  find . -type p -name *_tmp -delete
+  # Remove any previous downloads of empty grib files
+  find . -type f -name *.grib2 -size 0 -delete
+
   check_file_existence
   if [[ $? -eq 0 ]]; then
     return
-  elif [[ -e ${FILE_NAME} ]]; then
-    rm ${FILE_NAME}
   fi
 
   check_file_in_archive ${ARCHIVE}
@@ -149,7 +152,6 @@ download_hrrr() {
   fi
 
   TMP_FILE="${FILE_NAME}_tmp"
-  [[ -e ${TMP_FILE} ]] && rm $TMP_FILE
   mkfifo $TMP_FILE
 
   printf '\n'

--- a/scripts/HRRR/download_hrrr.sh
+++ b/scripts/HRRR/download_hrrr.sh
@@ -102,6 +102,8 @@ download_hrrr() {
   check_file_existence
   if [[ $? -eq 0 ]]; then
     return
+  elif [[ -e ${FILE_NAME} ]]; then
+    rm ${FILE_NAME}
   fi
 
   check_file_in_archive ${ARCHIVE}
@@ -142,6 +144,7 @@ download_hrrr() {
   fi
 
   TMP_FILE="${FILE_NAME}_tmp"
+  [[ -e ${TMP_FILE} ]] && rm $TMP_FILE
   mkfifo $TMP_FILE
 
   printf '\n'

--- a/scripts/HRRR/download_hrrr.sh
+++ b/scripts/HRRR/download_hrrr.sh
@@ -17,15 +17,16 @@
 # find -L . -name *.grib2 -type f | cut -d/ -f2 | uniq -c | grep -v '48 ' | tr -s ' ' | cut -d '.' -f 2
 #
 
-HRRR_VARS='TMP:2 m|RH:2 m|DPT: 2 m|UGRD:10 m|VGRD:10 m|TCDC:|APCP:surface|DSWRF:surface|HGT:surface'
-HRRR_FC_HOURS=( 1 6 )
+export HRRR_VARS='TMP:2 m|RH:2 m|DPT: 2 m|UGRD:10 m|VGRD:10 m|TCDC:|APCP:surface|DSWRF:surface|HGT:surface'
+export HRRR_FC_HOURS=(1 6)
+export HRRR_DAY_HOURS=$(seq 0 23)
 
-UofU_ARCHIVE='UofU'
-AWS_ARCHIVE='AWS'
-Google_ARCHIVE='Google'
-ARCHIVES=($UofU_ARCHIVE $AWS_ARCHIVE $Google_ARCHIVE)
+export GRIB_AREA="-112.322:-105.628 35.556:43.452"
 
-OMP_NUM_THREADS=${SLURM_NTASKS:-4}
+export UofU_ARCHIVE='UofU'
+export AWS_ARCHIVE='AWS'
+export Google_ARCHIVE='Google'
+export ARCHIVES=($UofU_ARCHIVE $AWS_ARCHIVE $Google_ARCHIVE)
 
 set_archive_url() {
   if [[ ! -v ALT_DATE ]]; then
@@ -35,13 +36,14 @@ set_archive_url() {
   fi
 
   if [ $1 == ${UofU_ARCHIVE} ]; then
-      ARCHIVE_URL="https://pando-rgw01.chpc.utah.edu/hrrr/sfc/${HRRR_DAY}/${FILE_NAME}"
+      export ARCHIVE_URL="https://pando-rgw01.chpc.utah.edu/hrrr/sfc/${HRRR_DAY}/${FILE_NAME}"
   elif [ $1 == ${AWS_ARCHIVE} ]; then
-      ARCHIVE_URL="https://noaa-hrrr-bdp-pds.s3.amazonaws.com/hrrr.${HRRR_DAY}/conus/${FILE_NAME}"
+      export ARCHIVE_URL="https://noaa-hrrr-bdp-pds.s3.amazonaws.com/hrrr.${HRRR_DAY}/conus/${FILE_NAME}"
   elif [ $1 == ${Google_ARCHIVE} ]; then
-      ARCHIVE_URL="https://storage.googleapis.com/high-resolution-rapid-refresh/hrrr.${HRRR_DAY}/conus/${FILE_NAME}"
+      export ARCHIVE_URL="https://storage.googleapis.com/high-resolution-rapid-refresh/hrrr.${HRRR_DAY}/conus/${FILE_NAME}"
   fi
 }
+export -f set_archive_url
 
 check_file_in_archive() {
   set_archive_url $1
@@ -56,6 +58,7 @@ check_file_in_archive() {
   unset ALT_DATE
   return 0
 }
+export -f check_file_in_archive
 
 check_alternate_archive() {
     for ALT_ARCHIVE in "${ARCHIVES[@]}"; do
@@ -74,6 +77,7 @@ check_alternate_archive() {
     touch "${FILE_NAME}.missing"
     return 1
 }
+export -f check_alternate_archive
 
 check_file_existence(){
   # Check for existing file and that it is not zero in size
@@ -86,100 +90,106 @@ check_file_existence(){
   fi
   return 1
 }
+export -f check_file_existence
 
+download_hrrr() {
+  DAY_HOUR=$1
+  FC_HOUR=$2
+  FILE_NAME="hrrr.t$(printf "%02d" $DAY_HOUR)z.wrfsfcf0${FC_HOUR}.grib2"
+
+  printf "  File: ${FILE_NAME}"
+
+  check_file_existence
+  if [[ $? -eq 0 ]]; then
+    return
+  fi
+
+  check_file_in_archive ${ARCHIVE}
+
+  if [ $? -eq 1 ]; then
+    check_alternate_archive
+  fi
+
+  if [ $? -eq 1 ]; then
+    >&2 printf "  ** File not available **\n"
+
+    # Try a previous hour of the day when getting the F06 forecast
+    if [[ ${FC_HOUR} -eq 6 ]]; then
+      NEW_DATE=$(date -u -d "${DATE} $(printf "%02d" $DAY_HOUR):00:00 1 hour ago" "+%Y%m%d%H")
+      ALT_DATE=${NEW_DATE:0:-2}
+      FILE_NAME="hrrr.t${NEW_DATE:(-2)}z.wrfsfcf0$(($FC_HOUR + 1)).grib2"
+
+      >&2 printf "  ** Checking previous hour: hrrr.${ALT_DATE}/${FILE_NAME}"
+
+      check_file_existence
+      if [[ $? -eq 0 ]]; then
+        unset ALT_DATE
+        return
+      fi
+      check_file_in_archive $ARCHIVE
+
+      if [[ $? -eq 1 ]]; then
+        check_alternate_archive
+
+        if [[ $? -eq 1 ]]; then
+          >&2 printf "  ** File not present in previous hour\n"
+          return
+        fi
+      fi
+    else
+      return
+    fi
+  fi
+
+  TMP_FILE="${FILE_NAME}_tmp"
+  mkfifo $TMP_FILE
+
+  printf '\n'
+  wget -q --no-check-certificate ${ARCHIVE_URL} -O $TMP_FILE | \
+  wgrib2 $TMP_FILE -v0 -set_grib_type same -small_grib ${GRIB_AREA} - | \
+  wgrib2 - -v0 -match "$HRRR_VARS" -grib $FILE_NAME >&1
+
+  rm $TMP_FILE
+
+  if [ $? -eq 0 ]; then
+    >&1 printf " created \n"
+  fi
+}
+export -f download_hrrr
+
+# Parse the given user inputs
 if [[ ! -z $2 ]] && [[ $2 != @($UofU_ARCHIVE|$AWS_ARCHIVE|$Google_ARCHIVE) ]]; then
-  YEAR=$1
-  MONTH=$2
-  LAST_DAY=$(date -d "${MONTH}/01/${YEAR} + 1 month - 1 day" +%d)
+  export YEAR=$1
+  export MONTH=$2
+  export LAST_DAY=$(date -d "${MONTH}/01/${YEAR} + 1 month - 1 day" +%d)
 
-  DATES=($(seq -f "${YEAR}${MONTH}%02g" 1 $LAST_DAY))
+  export DATES=($(seq -f "${YEAR}${MONTH}%02g" 1 $LAST_DAY))
 else
   IFS=','
-  DATES=($1)
+  export DATES=($1)
 fi
 
+# Set the archive
 if [[ "$2" == "${UofU_ARCHIVE}" ]] || [[ "$3" == "${UofU_ARCHIVE}" ]]; then
-  ARCHIVE=${UofU_ARCHIVE}
+  export ARCHIVE=${UofU_ARCHIVE}
 elif [[ "$2" == "${AWS_ARCHIVE}" ]] || [[ "$3" == "${AWS_ARCHIVE}" ]]; then
-  ARCHIVE=${AWS_ARCHIVE}
+  export ARCHIVE=${AWS_ARCHIVE}
 else
-  ARCHIVE=${Google_ARCHIVE}
+  export ARCHIVE=${Google_ARCHIVE}
 fi
 
 printf "Getting files from: ${ARCHIVE}\n"
 
+# Get the data
 for DATE in "${DATES[@]}"; do
   printf "Processing: $DATE\n"
+  export DATE=${DATE}
 
   FOLDER="hrrr.${DATE}"
   mkdir -p $FOLDER
   pushd $FOLDER > /dev/null
 
-  for DAY_HOUR in {0..23}; do
-    for FC_HOUR in "${HRRR_FC_HOURS[@]}"; do
-        FILE_NAME="hrrr.t$(printf "%02d" $DAY_HOUR)z.wrfsfcf0${FC_HOUR}.grib2"
-
-        printf "  File: ${FILE_NAME}"
-
-        check_file_existence
-        if [[ $? -eq 0 ]]; then
-          continue
-        fi
-
-        check_file_in_archive ${ARCHIVE}
-
-        if [ $? -eq 1 ]; then
-          check_alternate_archive
-        fi
-
-        if [ $? -eq 1 ]; then
-          >&2 printf "  ** File not available **\n"
-
-          # Try a previous hour of the day when getting the F06 forecast
-          if [[ ${FC_HOUR} -eq 6 ]]; then
-            NEW_DATE=$(date -u -d "${DATE} $(printf "%02d" $DAY_HOUR):00:00 1 hour ago" "+%Y%m%d%H")
-            ALT_DATE=${NEW_DATE:0:-2}
-            FILE_NAME="hrrr.t${NEW_DATE:(-2)}z.wrfsfcf0$(($FC_HOUR + 1)).grib2"
-
-            >&2 printf "  ** Checking previous hour: hrrr.${ALT_DATE}/${FILE_NAME}"
-
-            check_file_existence
-            if [[ $? -eq 0 ]]; then
-              unset ALT_DATE
-              continue
-            fi
-            check_file_in_archive $ARCHIVE
-
-            if [[ $? -eq 1 ]]; then
-              check_alternate_archive
-
-              if [[ $? -eq 1 ]]; then
-                >&2 printf "  ** File not present in previous hour\n"
-                continue
-              fi
-            fi
-          else
-            continue
-          fi
-        fi
-
-        TMP_FILE="${FILE_NAME}_tmp"
-        mkfifo $TMP_FILE
-
-        printf '\n'
-        wget -q --no-check-certificate ${ARCHIVE_URL} -O $TMP_FILE | \
-        wgrib2 $TMP_FILE -v0 -ncpu ${OMP_NUM_THREADS} -set_grib_type same \
-               -small_grib -112.322:-105.628 35.556:43.452 - | \
-        wgrib2 - -v0 -ncpu ${OMP_NUM_THREADS} -match "$HRRR_VARS" \
-               -grib $FILE_NAME >&1
-
-        rm $TMP_FILE
-
-        if [ $? -eq 0 ]; then
-          >&1 printf " created \n"
-        fi
-    done
-  done
+  parallel --tag --line-buffer --jobs ${SLURM_NTASKS} download_hrrr ::: ${HRRR_DAY_HOURS} ::: "${HRRR_FC_HOURS[@]}"
 
   popd > /dev/null
 done


### PR DESCRIPTION
Following edits:
* Speed up the HRRR data download by using the `parallel` command
* Small convenience features to remove 0-sized or temporary files (highlighted via comment)
* Move the most relevant variables to the top of the script for easier editing/adjusting to one's needs
* Remove the archive step from SLURM example since it is public data to begin with