### PR TITLE
Katana parallel

### DIFF
--- a/scripts/katana/katana.ini
+++ b/scripts/katana/katana.ini
@@ -14,7 +14,7 @@ hrrr_num_wgrib_threads: 24
 
 [output]
 out_location:     /data/output
-wn_cfg:           /data/output/katana.ini
+wn_cfg:           /data/output/katana_wn.ini
 make_new_gribs:   true
 
 [logging]

--- a/scripts/katana/katana.slurm
+++ b/scripts/katana/katana.slurm
@@ -62,9 +62,9 @@ for MONTH in {0..11}; do
   fi
 done
 
-  # Unused  katana output files by iSnobal
-  find ${KATANA_OUTPUT_DIR} -name *.prj -type f -delete
-  find ${KATANA_OUTPUT_DIR} -name *_cld.asc -type f -delete
-  ## Unused temporary grib files created by katana
-  find ${KATANA_OUTPUT_DIR} -name *.grib2 -type f -delete
-  find ${KATANA_OUTPUT_DIR} -name hrrr.* -type d -empty -delete
+# Unused  katana output files by iSnobal
+find ${KATANA_OUTPUT_DIR} -name *.prj -type f -delete
+find ${KATANA_OUTPUT_DIR} -name *_cld.asc -type f -delete
+## Unused temporary grib files created by katana
+find ${KATANA_OUTPUT_DIR} -name *.grib2 -type f -delete
+find ${KATANA_OUTPUT_DIR} -name hrrr.* -type d -empty -delete

--- a/scripts/katana/katana.slurm
+++ b/scripts/katana/katana.slurm
@@ -50,6 +50,9 @@ for MONTH in {0..11}; do
   # Update the config to the month processed
   sed -i -e "s/^start_date: .* UTC/start_date: ${YEAR}-${MONTH}-01 00:00:00 UTC/g" ${MONTH_INI}
   sed -i -e "s/^end_date: .* UTC/end_date: ${YEAR_END}-${MONTH_END}-01 00:00:00 UTC/g" ${MONTH_INI}
+  # Update config file (line 17) and log path (line 22)
+  sed -i -e "17s/katana_wn\.ini/katana_wn_${YEAR}${MONTH}\.ini/" ${MONTH_INI}
+  sed -i -e "22s/katana\.log/katana_${YEAR}${MONTH}\.log/" ${MONTH_INI}
 
   # Map local file paths to container paths
   export SINGULARITY_BIND="${BASIN_SETUP}:/data/topo,${INPUT_DIR}:/data/input,${KATANA_OUTPUT_DIR}:/data/output"


### PR DESCRIPTION
Update slurm and .ini file to enable parallel runs of the same slurm job. This required updating the written WindNinja config by katana and the log file to have a datestamp as well.