### PR TITLE
Package - Print dask client IP subset in context helper

### DIFF
--- a/package/src/snobedo/lib/dask_utils.py
+++ b/package/src/snobedo/lib/dask_utils.py
@@ -54,7 +54,7 @@ def slurm_script(client):
 @contextmanager
 def run_with_client(cores, memory):
     client = start_cluster(cores, memory)
-    print(client.dashboard_link)
+    print(client_ip_and_port(client))
     try:
         yield client
     finally:


### PR DESCRIPTION
Only partially print the dashboard address so it can be used via copay and paste for a terminal port forward.