### PR TITLE
Conda - Basin Setup - Pin some package versions

### DIFF
--- a/conda/basin_setup/basin_setup.yaml
+++ b/conda/basin_setup/basin_setup.yaml
@@ -4,12 +4,13 @@ channels:
 dependencies:
   - colorama
   - coloredlogs
+  - gdal<3.9
   - geopandas
   - netcdf4
   - numpy<1.25
   - pandas
   - pip
-  - python
+  - python=3.11
   - rioxarray
   - xarray
   - pip:


### PR DESCRIPTION
Specifically gdal < 3.9 and python to 3.11