### PR TITLE
Scripts - HRRR - improve log output

### DIFF
--- a/scripts/HRRR/download_hrrr.sh
+++ b/scripts/HRRR/download_hrrr.sh
@@ -29,6 +29,8 @@ export GRIB_AREA="-122.00:-105.00 32.00:49.00"
 PARALLEL_JOBS=16
 ## Number of Grib threads
 export GRIB_THREADS="-ncpu 2"
+## Log control
+export LOG_OUTPUT="true"
 
 # When adding a new archive, also add the variable to function:
 #  check_alternate_archive
@@ -102,7 +104,9 @@ export -f check_alternate_archive
 check_file_existence(){
   # Check for existing file on disk and that it is not zero in size
   if [[ -s "${FILE_NAME}" ]]; then
-    >&1 printf "  exists \n"
+    if [[ "${1}" == "${LOG_OUTPUT}" ]]; then
+      >&1 printf "  exists \n"
+    fi
     exit 0
   fi
   return 3
@@ -133,8 +137,8 @@ download_hrrr() {
   find . -type f -name ${FILE_NAME} -size 0 -delete
   # Remove any previously missing files in archives and try again
   find . -type f -name "${FILE_NAME}.missing" -size 0 -delete
-
-  check_file_existence
+ 
+  check_file_existence ${LOG_OUTPUT}
 
   check_file_in_archive ${ARCHIVE}
 


### PR DESCRIPTION
Add an optional argument to the `check_file_existence` method to control logging of the successful check. Now that this method is used more than once, the logs got filled with "exists" messages.

Related to GH-83