### PR TITLE
Conda - bump new version for AWSM

### DIFF
--- a/conda/environment.yaml
+++ b/conda/environment.yaml
@@ -26,4 +26,4 @@ dependencies:
 - pip:
     - inicheck
     - spatialnc
-    - git+https://github.com/UofU-Cryosphere/awsm.git@20250630
+    - git+https://github.com/UofU-Cryosphere/awsm.git@20250722


### PR DESCRIPTION
Making the latest AWSM tag 20250722 the general version to use in the isnoda environment.

This depends on https://github.com/UofU-Cryosphere/awsm/pull/9 being merged and a new release being cut afterwards.