### PR TITLE
Scripts - HRRR - Add conda environment

### DIFF
--- a/scripts/HRRR/hrrr.yaml
+++ b/scripts/HRRR/hrrr.yaml
@@ -1,0 +1,7 @@
+name: hrrr
+channels:
+  - conda-forge
+dependencies:
+  - parallel
+  - wget
+  - wgrib2


### PR DESCRIPTION
To make it easier to use the download_hrrr.sh script across HPC environments.

This is a lesson from setting up the model at UVM and the wgrib2 command was not available.